### PR TITLE
chore: bump rtc-sdk to 0.3 and rtc-kit-react to 0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@callpromn/rtc-kit": "0.1.0",
-        "@callpromn/rtc-kit-react": "0.1.5",
-        "@callpromn/rtc-sdk": "0.2.2",
+        "@callpromn/rtc-kit-react": "^0.2.0",
+        "@callpromn/rtc-sdk": "^0.3.0",
         "lucide-react": "^0.539.0",
         "next": "^16.2.12",
         "react": "19.1.0",
@@ -287,13 +287,13 @@
       "license": "MIT"
     },
     "node_modules/@callpromn/rtc-kit-react": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/@callpromn/rtc-kit-react/-/rtc-kit-react-0.1.5.tgz",
-      "integrity": "sha512-TkakcXvjrJb3dsTmw05eipdkxHfVqftlECmGlG1eDpyheiCxysWfuSFshKEXBUHx+4jGkxZ3C+33SXW4H1f95w==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@callpromn/rtc-kit-react/-/rtc-kit-react-0.2.0.tgz",
+      "integrity": "sha512-wl28BtItVW3PMPE/azjSVijGV48Iyh3GLvBx5l9Tu9eM73bLqP8m3o7IUTUHK5ZjM8GOH7zN2nhzo39OTVKH7A==",
       "license": "MIT",
       "dependencies": {
         "@callpromn/rtc-kit": "^0.1.0",
-        "@callpromn/rtc-sdk": "^0.2.2"
+        "@callpromn/rtc-sdk": "^0.3.0"
       },
       "peerDependencies": {
         "react": ">=18",
@@ -301,9 +301,9 @@
       }
     },
     "node_modules/@callpromn/rtc-sdk": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@callpromn/rtc-sdk/-/rtc-sdk-0.2.2.tgz",
-      "integrity": "sha512-6x7l1Tk05YQAqRgkYVgLdWiTucAZUH6jaEoKoRww9AixLfAyFNWoOFyzLa46ElpTDetI3FFwvoAGNvJeuBsAuw==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@callpromn/rtc-sdk/-/rtc-sdk-0.3.0.tgz",
+      "integrity": "sha512-vWsMh3o0nnEi3bJlPwvnfJ8d/k7/CdCRPi6C5MQo4RMNrdo4iFCYnpHe1fZdMIBv1l8HqPwyltMzVQpWW0mYTQ==",
       "license": "MIT",
       "dependencies": {
         "socket.io-client": "^4.8.1",
@@ -6769,9 +6769,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.21.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
-      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
   },
   "dependencies": {
     "@callpromn/rtc-kit": "0.1.0",
-    "@callpromn/rtc-kit-react": "0.1.5",
-    "@callpromn/rtc-sdk": "0.2.2",
+    "@callpromn/rtc-kit-react": "^0.2.0",
+    "@callpromn/rtc-sdk": "^0.3.0",
     "lucide-react": "^0.539.0",
     "next": "^16.2.12",
     "react": "19.1.0",


### PR DESCRIPTION
## What changed

- `@callpromn/rtc-sdk`: `0.2.2` → `^0.3.0`
- `@callpromn/rtc-kit-react`: `0.1.5` → `^0.2.0`
- Transitive `ws` lockfile bump `8.21.1` → `8.21.3`

Both direct deps switch from exact pins to caret ranges. No source changes were required — the new SDK versions are drop-in for everything this quickstart uses.

## Why

The exact pins meant every upstream SDK release needed a manual edit plus a lockfile commit here. A quickstart sample should track the latest published SDK, so caret ranges are the right default. `@callpromn/rtc-kit` stays pinned at `0.1.0` since `rtc-kit-react` already depends on `^0.1.0`.

## How to test

```bash
npm install
npx tsc --noEmit   # clean
npm run lint       # clean
npm run build      # succeeds, all 8 pages generated
npm run dev        # exercise /, /core, /webcomponent — place a call, verify audio/video and the call timer
```

The build/lint/type-check gates were all run on this branch and pass. The dev-server call flow needs live credentials, so a reviewer should verify that manually.
